### PR TITLE
Fix form data encoding issue that prevented a hard refresh

### DIFF
--- a/popup/ui.js
+++ b/popup/ui.js
@@ -49,20 +49,9 @@ var helper_ui = new Vue({
 		changeTheme: function() {
 			var new_theme = this.preview;
 			getTabLocation(function(loc) {
-				var new_query = loc.query;
-				if (/(^|&)nview={0,1}.*?($|&)/.test(new_query)) {
-					new_query = new_query.replace(/(^|&)nview={0,1}.*?($|&)/,"");
-				}
-				console.log('new_query after replace');
-				console.log(new_query);
-				
-				if (new_query.length > 0) {
-					new_query+="&"
-				}
-				new_query+="nview="+new_theme;
-				console.log("new url");
-				console.log(loc.domain, loc.path, new_query);
-				changeLocation(loc.id, "https://"+loc.domain+"/"+loc.path+"?"+new_query);
+				let new_query = loc.query;
+				new_query.set('nview',new_theme);
+				changeLocation(loc.id, "https://"+loc.domain+loc.path+"?"+new_query);
 			});
 		},
 		checkNView: function() {

--- a/storage.js
+++ b/storage.js
@@ -276,7 +276,7 @@ async function postPage(url, parameters={}) {
 		let uri = `https://${url}`
 		let opts = {
 			method: "POST",
-			body: jsonToFormData(parameters),
+			body: new URLSearchParams(parameters),
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded"
 			}
@@ -293,13 +293,3 @@ async function postPage(url, parameters={}) {
 			)
 	})
 }
-
-/**
- * Converts a JSON object into a form data string. Does not support nested data.
- * @param {object} json the JSON object.
- * @returns {string} the encoded form data.
- */
-const jsonToFormData = json =>
-  Object.keys(json)
-    .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(json[key]))
-    .join("&");

--- a/storage.js
+++ b/storage.js
@@ -122,13 +122,15 @@ function changeLocation(tab_id, url) {
 }
 
 function extractDomain(full_url) {
-	return full_url.replace(/http.*\/\//,"").replace(/\/.*/,"").replace(/\?.*/,"");
+	return new URL(full_url).host;
 }
 function extractPath(full_url) {
-	return full_url.replace(/http.*\/\//,"").replace(/.*?(\/|$)/,"").replace(/\?.*/,"");
+	let path = new URL(full_url).pathname;
+	// remove the leading slash from the path
+	return path.substring(1);
 }
 function extractQueryString(full_url) {
-	return full_url.replace(/.*?(\?|$)/,"")
+	return new URL(full_url).searchParams;
 }
 
 function create_netosd_data(data, sp) {

--- a/storage.js
+++ b/storage.js
@@ -276,10 +276,7 @@ async function postPage(url, parameters={}) {
 		let uri = `https://${url}`
 		let opts = {
 			method: "POST",
-			body: new URLSearchParams(parameters),
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded"
-			}
+			body: new URLSearchParams(parameters)
 		}
 		fetch(uri, opts)
 			.then(

--- a/storage.js
+++ b/storage.js
@@ -276,7 +276,7 @@ async function postPage(url, parameters={}) {
 		let uri = `https://${url}`
 		let opts = {
 			method: "POST",
-			body: JSON.stringify(parameters),
+			body: jsonToFormData(parameters),
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded"
 			}
@@ -293,3 +293,13 @@ async function postPage(url, parameters={}) {
 			)
 	})
 }
+
+/**
+ * Converts a JSON object into a form data string. Does not supported nested data.
+ * @param {object} json the JSON object.
+ * @returns {string} the encoded form data.
+ */
+const jsonToFormData = json =>
+  Object.keys(json)
+    .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(json[key]))
+    .join("&");

--- a/storage.js
+++ b/storage.js
@@ -295,7 +295,7 @@ async function postPage(url, parameters={}) {
 }
 
 /**
- * Converts a JSON object into a form data string. Does not supported nested data.
+ * Converts a JSON object into a form data string. Does not support nested data.
  * @param {object} json the JSON object.
  * @returns {string} the encoded form data.
  */


### PR DESCRIPTION
Previously the `NETO_CSS_VERSION` was never updated during a heavy purge because the server didn't know how to parse the JSON body of the POST request. 

Now the JSON is properly parsed into form data before the request is posted. 

I've also refactored some regex URL methods to use the URL class. 

Happy days! 